### PR TITLE
Fix check for regex to support new `Array#lastIndex` proposal

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function findAndReplace(tree, find, replace, options) {
 
   if (
     typeof find === 'string' ||
-    (find && typeof find.lastIndex === 'number')
+    (find && typeof find.exec === 'function')
   ) {
     schema = [[find, replace]]
   } else {


### PR DESCRIPTION
There’s a proposal for `Array#lastIndex` which may cause a false positive: https://github.com/tc39/proposal-array-last

see https://github.com/syntax-tree/mdast-util-find-and-replace/commit/536e7e5d23efd16dffb96fb0148eda922636940e#r46933368

<!--

Read the [contributing guidelines](https://github.com/syntax-tree/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/syntax-tree/.github/blob/main/support.md
https://github.com/syntax-tree/.github/blob/main/contributing.md
-->
