### PR TITLE
Add unit test for adjacent matches in the same text node

### DIFF
--- a/test.js
+++ b/test.js
@@ -464,6 +464,28 @@ test('findAndReplace', async function (t) {
       ])
     )
   })
+
+  await t.test(
+    'should replace multiple matches in the same node',
+    async function () {
+      const tree = create()
+
+      findAndReplace(tree, [/(emph|sis)/g, 'foo'])
+
+      assert.deepEqual(
+        tree,
+        u('paragraph', [
+          u('text', 'Some '),
+          u('emphasis', [u('text', 'foo'), u('text', 'a'), u('text', 'foo')]),
+          u('text', ', '),
+          u('strong', [u('text', 'importance')]),
+          u('text', ', and '),
+          u('inlineCode', 'code'),
+          u('text', '.')
+        ])
+      )
+    }
+  )
 })
 
 function create() {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add a unit test to check that multiple matches in the same text node are replaced.

<!--do not edit: pr-->
